### PR TITLE
Fixes print format warning and missing library (needed for linking)

### DIFF
--- a/proton-c-queues-and-topics/Makefile
+++ b/proton-c-queues-and-topics/Makefile
@@ -25,6 +25,7 @@ PROTONROOT := ~/proton/qpid-proton-0.$(PROTONVER)
 PROTONLIBVER := 2
 
 CFLAGS := -g -DSERVICEBUS_DOMAIN="\"servicebus.windows.net\""
+LDFLAGS := -luuid
 
 OPTS := -I $(PROTONROOT)/proton-c/include \
 	-I $(PROTONROOT)/build/proton-c/include
@@ -56,14 +57,14 @@ $(BINDIR)/0$(PROTONVER):
 
 $(BINDIR)/0$(PROTONVER)/sender0$(PROTONVER):	\
 	$(OBJDIR)/sender0$(PROTONVER).o $(OBJDIR)/common0$(PROTONVER).o
-	$(CC) $(CFLAGS) -o $@ $^ $(LIBS)
+	$(CC) $(CFLAGS) -o $@ $^ $(LIBS) $(LDFLAGS)
 
 $(OBJDIR)/sender0$(PROTONVER).o:	sender.c common.h
 	$(CC) $(CFLAGS) -c $(OPTS) -o $@ $<
 
 $(BINDIR)/0$(PROTONVER)/receiver0$(PROTONVER):	\
 	$(OBJDIR)/receiver0$(PROTONVER).o $(OBJDIR)/common0$(PROTONVER).o
-	$(CC) $(CFLAGS) -o $@ $^ $(LIBS)
+	$(CC) $(CFLAGS) -o $@ $^ $(LIBS) $(LDFLAGS)
 
 $(OBJDIR)/receiver0$(PROTONVER).o:	receiver.c common.h
 	$(CC) $(CFLAGS) -c $(OPTS) -o $@ $<

--- a/proton-c-queues-and-topics/receiver.c
+++ b/proton-c-queues-and-topics/receiver.c
@@ -126,11 +126,11 @@ int receive(char *sbnamespace, char *entity, char *issuerName, char *issuerKey)
     printf("CALL pn_messenger_subscribe... ");
     pn_subscription_t *subscription =
         pn_messenger_subscribe(messenger, address);
-    printf("RETURNED\n", err);
+    printf("RETURNED\n");
     if (NULL == subscription)
     {
         printf("pn_messenger_subscribe returned NULL\n");
-        printf("%s", pn_messenger_error(messenger));
+        printf("%s", pn_error_text(pn_messenger_error(messenger)));
         return -1;
     }
 


### PR DESCRIPTION
This patch aims to : 
 - fix a `printf` format warning in the receiver
 - Use the `pn_error_text()` to get the text for the error.
 - add missing library `uuid` in the Makefile.
